### PR TITLE
inject whole head in header and footer

### DIFF
--- a/lib/scripts/pdf_a4_portrait.js
+++ b/lib/scripts/pdf_a4_portrait.js
@@ -61,7 +61,7 @@
 
   content = page.evaluate(function() {
     var $body, $footer, $header, body, footer, header, ref1, styles;
-    styles = ((ref1 = document.querySelector('head style')) != null ? ref1.outerHTML : void 0) || '';
+    styles = ((ref1 = document.querySelector('head')) != null ? ref1.outerHTML : void 0) || '';
     if ($header = document.getElementById('pageHeader')) {
       header = $header.outerHTML;
       $header.parentNode.removeChild($header);

--- a/src/scripts/pdf_a4_portrait.coffee
+++ b/src/scripts/pdf_a4_portrait.coffee
@@ -46,7 +46,7 @@ page.onError = (msg, trace) ->
 # Set up content
 # --------------
 content = page.evaluate ->
-  styles = document.querySelector('head style')?.outerHTML || ''
+  styles = document.querySelector('head')?.outerHTML || ''
   if $header = document.getElementById('pageHeader')
     header = $header.outerHTML
     $header.parentNode.removeChild($header)


### PR DESCRIPTION
The change allow the following imporvements:

1. Use `link` elements defined in the head also into the header and footer
2. Use multiple `style` tags. right now the selector would only take the first `style` tag and ignore the others

I am using it right now and I can't see any downside of this approach