### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+# Development Files
+src/
+test/
+
+# Example Files
+example/
+*.pdf
+
+# Travis CI Files
+.travis.yml


### PR DESCRIPTION
Added `.npmignore` to ignore dev files from dist.

Goal is to make this module bandwidth efficient. 
Even though in this case it only saves a few KB, I think it's a best practice to include `.npmignore` in every module.

· `test` and `src` don't work without the `devDependencies`, so are useless in production.
· `examples` are accessible from the documentation (GitHub), so they don't really need to be downloaded every time the module is required.
