### PR TITLE
Option for waiting for event to trigger

### DIFF
--- a/lib/scripts/pdf_a4_portrait.js
+++ b/lib/scripts/pdf_a4_portrait.js
@@ -63,10 +63,26 @@ page.onLoadFinished = function (status) {
   }
 
   var filename = options.filename || (options.directory || '/tmp') + '/html-pdf-' + system.pid + '.' + fileOptions.type
-  page.render(filename, fileOptions)
-  system.stdout.write(JSON.stringify({filename: filename}))
 
-  exit(null)
+  takeShot();
+  function takeShot(){
+    var title = page.evaluate(function() {
+      return document.title;
+    });
+
+    if(title.toUpperCase() != "DONE" && options.onTitleDone){
+      window.setTimeout(function () {
+        takeShot();
+      }, 400);
+    } else {
+      page.render(filename, fileOptions)
+      phantom.exit();
+
+      system.stdout.write(JSON.stringify({filename: filename}))
+
+      exit(null)
+    }
+  }
 }
 
 // Returns a hash of HTML content


### PR DESCRIPTION
Curious if this would be useful for other users as we found dealing with canvas elements something like this was needed as PDF's were generated before the canvas element had fully rendered.

Added an option to allow waiting for the page to say when it's finished rendering.

If `options.onTitleDone` is set to `true`, the page will not take the screenshot until the title is set to "done" on the page.

So, in the document, once everything has finished run `document.title = "done"`
