### PR TITLE
Allow setting page.paperSize from options explicitly

### DIFF
--- a/lib/scripts/pdf_a4_portrait.js
+++ b/lib/scripts/pdf_a4_portrait.js
@@ -54,7 +54,7 @@ setTimeout(function () {
 // ----------------------------------
 page.onLoadFinished = function (status) {
   // The paperSize object must be set at once
-  page.paperSize = definePaperSize(getContent(page), options)
+  page.paperSize = options.paperSize || definePaperSize(getContent(page), options)
 
   // Output to parent process
   var fileOptions = {


### PR DESCRIPTION
## Motivation
http://phantomjs.org/api/webpage/property/paper-size.html

> If no `paperSize` is defined, the size is defined by the web page.

Currently `paperSize` is always defined, so size auto detection is unusable, although I personally sometimes need it.

## Problem
I couldn't find a way in PhantomJS to turn on size auto detection and use headers/footers at the same time. So, adding options like `format: 'auto' ` seems unreasonable because it would break other options.

## Variant of solution
Well.. allowing users to set PhantomJS pageSize to what they exactly want seems to work just find and it must be quite obvious that setting it manually will overwrite other options. And setting it to
empty object (`{}`) does the work and turns on page size auto detection, so it's a kind of solution.

Maybe having something like `pageSize: 'auto'` is better, but I'm not really sure.

Comments appreciated.
P.S. If I missed something like contributing guidelines, I'll be glad if you point me to them.