### PR TITLE
Handle spawn errors gracefully.

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -84,6 +84,7 @@ PDF.prototype.toFile = function PdfToFile (filename, callback) {
 }
 
 PDF.prototype.exec = function PdfExec (callback) {
+  var callbacked = false
   var child = childprocess.spawn(this.options.phantomPath, [].concat(this.options.phantomArgs, [this.script]))
   var stdout = []
   var stderr = []
@@ -105,25 +106,29 @@ PDF.prototype.exec = function PdfExec (callback) {
     return child.kill()
   })
 
-  child.on('error', function (error) {
+  function exit (err, data) {
+    if (callbacked) return
+    callbacked = true
     clearTimeout(timeout)
-    return callback(error)
-  })
+    if (err) return callback(err)
+    return callback(null, data)
+  }
+
+  child.on('error', exit)
 
   child.on('exit', function (code) {
-    clearTimeout(timeout)
     if (code || stderr.length) {
       var err = new Error(Buffer.concat(stderr).toString() || 'html-pdf: Unknown Error')
-      return callback(err)
+      return exit(err)
     } else {
       try {
         var buff = Buffer.concat(stdout).toString()
         var data = (buff) != null ? buff.trim() : undefined
         data = JSON.parse(data)
       } catch (err) {
-        return callback(err)
+        return exit(err)
       }
-      return callback(null, data)
+      return exit(null, data)
     }
   })
 

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -105,6 +105,11 @@ PDF.prototype.exec = function PdfExec (callback) {
     return child.kill()
   })
 
+  child.on('error', function (error) {
+    clearTimeout(timeout)
+    return callback(error)
+  })
+
   child.on('exit', function (code) {
     clearTimeout(timeout)
     if (code || stderr.length) {

--- a/test/index.js
+++ b/test/index.js
@@ -114,6 +114,24 @@ test('allows custom html and css', function (t) {
   })
 })
 
+test('allows invalid phantomPath', function (t) {
+  t.plan(3)
+
+  var filename = path.join(__dirname, 'invalid-phantomPath.pdf')
+
+  var options = {
+    phantomPath: '/bad/path/to/phantom'
+  }
+
+  pdf
+  .create(html, options)
+  .toFile(filename, function (error, pdf) {
+    t.assert(error instanceof Error, 'Returns an error')
+    t.equal(error.code, 'ENOENT', 'Error code is ENOENT')
+    t.error(pdf, 'PDF does not exist')
+  })
+})
+
 test('allows custom page and footer options', function (t) {
   t.plan(3)
 


### PR DESCRIPTION
If an invalid options.phantomPath was provided, the entire application would crash.  Now it handles errors gracefully and passes them to the callback.