### PR TITLE
Pull request: add more folio customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,14 @@ config = {
   },
   "footer": {
     "height": "28mm",
-    "contents": '<span style="color: #444;">{{page}}</span>/<span>{{pages}}</span>'
+    "contents": '<span style="color: #444;">{{page}}</span>/<span>{{pages}}</span>',
+    "folio": {
+      "start": 0,
+      "substitute": [
+        "Cover",
+        "Table of Contents"
+      ]
+    }
   },
 
 

--- a/lib/scripts/pdf_a4_portrait.js
+++ b/lib/scripts/pdf_a4_portrait.js
@@ -146,8 +146,7 @@ function createSection (section, content, options) {
   var c = content[section] || {}
   var o = options[section] || {}
   var f = o.folio || {};
-
-  s = f.substitute || [];
+  var s = f.substitute || [];
 
   return {
     height: o.height,

--- a/lib/scripts/pdf_a4_portrait.js
+++ b/lib/scripts/pdf_a4_portrait.js
@@ -145,6 +145,9 @@ function getContent (page) {
 function createSection (section, content, options) {
   var c = content[section] || {}
   var o = options[section] || {}
+  var f = o.folio || {};
+
+  s = f.substitute || [];
 
   return {
     height: o.height,
@@ -152,8 +155,14 @@ function createSection (section, content, options) {
       var html = c[pageNum]
       if (pageNum === 1 && !html) html = c.first
       if (pageNum === numPages && !html) html = c.last
+
+      if (f.start) {
+        pageNum -= o.folio.start;
+        numPages -= o.folio.start;
+      }
+
       return (html || c.default || o.contents || '')
-        .replace('{{page}}', pageNum)
+        .replace('{{page}}', s[pageNum-1] || (pageNum > 0 ? pageNum : ''))
         .replace('{{pages}}', numPages) + content.styles
     })
   }


### PR DESCRIPTION
Specify some folio behavior in the options JSON object under `options.footer.folio`.

Currently, there is no control over how the pages are numbered... If you want to have a Cover page and then 1, 2, 3, etc. or if you want to page normally but have the first page say "cover" and then the second say "table of contents" etc.

```
"footer": {
    "folio": {
        "start": 1,
        "substitute": [
            "Cover",
            "Table of Contents"
        ]
    }
}
```

This makes the pages start counting on the second page (the first page being 0, aka not showing). It also replaces the folio on page 1 with "Cover" and page two with "Table of Contents."