### PR TITLE
Exposing zoomFactor in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ config = {
 
   // Rendering options
   "base": "file:///home/www/your-asset-path", // Base path that's used to load files (images, css, js) when they aren't referenced using a host
+  
+  // Zooming options
+  "zoomFactor": "1", // default is 1
 
   // File options
   "type": "pdf",             // allowed file types: png, jpeg, pdf

--- a/lib/scripts/pdf_a4_portrait.js
+++ b/lib/scripts/pdf_a4_portrait.js
@@ -35,6 +35,7 @@ var page = webpage.create()
 
 if (options.httpHeaders) page.customHeaders = options.httpHeaders
 if (options.viewportSize) page.viewportSize = options.viewportSize
+if (options.zoomFactor) page.zoomFactor = options.zoomFactor
 if (options.base) page.setContent(json.html, options.base)
 else page.setContent(json.html, null)
 


### PR DESCRIPTION
`zoomFactor` is an important factor when rendering webpages, especially when the webpage is exported as png/jpg. Given that the dpi of the images rendered by PhantamJS is relatively low, many clients choose to adjust the `zoomFactor` to get better image quality.

Therefore,  I would like to expose this factor to clients.

