### PR TITLE
Add an option to render when window.callPhantom is called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,3 @@
 *.pdf
 !example/businesscard.pdf
 node_modules
-
-# swap
-[._]*.s[a-w][a-z]
-[._]s[a-w][a-z]
-# session
-Session.vim
-# temporary
-.netrwhist
-*~
-# auto-generated tag files
-tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
 *.pdf
 !example/businesscard.pdf
 node_modules
+
+# swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags

--- a/lib/scripts/pdf_a4_portrait.js
+++ b/lib/scripts/pdf_a4_portrait.js
@@ -53,7 +53,7 @@ setTimeout(function () {
 
 // Completely load page & end process
 // ----------------------------------
-page.onLoadFinished = function (status) {
+function renderPage(status) {
   // The paperSize object must be set at once
   page.paperSize = definePaperSize(getContent(page), options)
 
@@ -68,6 +68,13 @@ page.onLoadFinished = function (status) {
   system.stdout.write(JSON.stringify({filename: filename}))
 
   exit(null)
+}
+
+if (options.useDoneCallback) {
+  page.onCallback = renderPage
+}
+else {
+  page.onLoadFinished = renderPage
 }
 
 // Returns a hash of HTML content

--- a/test/external-js-callback.html
+++ b/test/external-js-callback.html
@@ -1,0 +1,28 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <style>
+      body {
+        font-family: "Helvetica Neue", sans-serif;
+        background: #F0F0F0;
+        color: #333;
+      }
+
+      * {
+        border: 0;
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="pageHeader">Header</div>
+    <div id="pageContent">Failed to execute. This must be a bug.</div>
+    <div id="pageFooter">Footer</div>
+    <script>
+      jQuery('#pageContent').text('Javascript executed correctly. Hooray.')
+      window.callPhantom('hi ma!')
+    </script>
+  </body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,33 @@ var html = fs.readFileSync(path.join(__dirname, 'example.html'), 'utf8')
 //
 // API
 //
+
+test('pdf.create(html[, options]).toFile([filename, {useDoneCallback: true}], callback), where html does not call window#callPhantom', function (t) {
+  t.plan(1)
+
+  var enrichedHtml = fs.readFileSync(path.join(__dirname, 'external-js.html'), 'utf8')
+  var filename = path.join(__dirname, 'external-js-callback-fail.pdf')
+  pdf
+  .create(enrichedHtml, {timeout: 2000, useDoneCallback: true, phantomArgs: ['--ignore-ssl-errors=true']})
+  .toFile(filename, function (error, pdf) {
+    t.assert(error instanceof Error, 'pdf.create(html, {useDoneCallback: true}) where callback not called')
+  })
+})
+
+test('pdf.create(html[, options]).toFile([filename, {useDoneCallback: true}], callback), where html calls window#callPhantom', function (t) {
+  t.plan(3)
+
+  var enrichedHtml = fs.readFileSync(path.join(__dirname, 'external-js-callback.html'), 'utf8')
+  var filename = path.join(__dirname, 'external-js-callback.pdf')
+  pdf
+  .create(enrichedHtml, {useDoneCallback: true, phantomArgs: ['--ignore-ssl-errors=true']})
+  .toFile(filename, function (error, pdf) {
+    t.error(error)
+    t.assert(pdf.filename == filename, 'Returns the filename from the phantom script')
+    t.assert(fs.existsSync(pdf.filename), 'Saves the pdf with a custom page size and footer')
+  })
+})
+
 test('pdf.create(html[, options]) throws an error when executing without html', function (t) {
   t.plan(3)
 

--- a/test/index.js
+++ b/test/index.js
@@ -13,32 +13,6 @@ var html = fs.readFileSync(path.join(__dirname, 'example.html'), 'utf8')
 // API
 //
 
-test('pdf.create(html[, options]).toFile([filename, {useDoneCallback: true}], callback), where html does not call window#callPhantom', function (t) {
-  t.plan(1)
-
-  var enrichedHtml = fs.readFileSync(path.join(__dirname, 'external-js.html'), 'utf8')
-  var filename = path.join(__dirname, 'external-js-callback-fail.pdf')
-  pdf
-  .create(enrichedHtml, {timeout: 2000, useDoneCallback: true, phantomArgs: ['--ignore-ssl-errors=true']})
-  .toFile(filename, function (error, pdf) {
-    t.assert(error instanceof Error, 'pdf.create(html, {useDoneCallback: true}) where callback not called')
-  })
-})
-
-test('pdf.create(html[, options]).toFile([filename, {useDoneCallback: true}], callback), where html calls window#callPhantom', function (t) {
-  t.plan(3)
-
-  var enrichedHtml = fs.readFileSync(path.join(__dirname, 'external-js-callback.html'), 'utf8')
-  var filename = path.join(__dirname, 'external-js-callback.pdf')
-  pdf
-  .create(enrichedHtml, {useDoneCallback: true, phantomArgs: ['--ignore-ssl-errors=true']})
-  .toFile(filename, function (error, pdf) {
-    t.error(error)
-    t.assert(pdf.filename == filename, 'Returns the filename from the phantom script')
-    t.assert(fs.existsSync(pdf.filename), 'Saves the pdf with a custom page size and footer')
-  })
-})
-
 test('pdf.create(html[, options]) throws an error when executing without html', function (t) {
   t.plan(3)
 
@@ -215,6 +189,32 @@ test('load external js', function (t) {
   var filename = path.join(__dirname, 'external-js.pdf')
   pdf
   .create(enrichedHtml, {phantomArgs: ['--ignore-ssl-errors=true']})
+  .toFile(filename, function (error, pdf) {
+    t.error(error)
+    t.assert(pdf.filename == filename, 'Returns the filename from the phantom script')
+    t.assert(fs.existsSync(pdf.filename), 'Saves the pdf with a custom page size and footer')
+  })
+})
+
+test('pdf.create(html[, options]).toFile([filename, {useDoneCallback: true}], callback), where html does not call window#callPhantom', function (t) {
+  t.plan(1)
+
+  var enrichedHtml = fs.readFileSync(path.join(__dirname, 'external-js.html'), 'utf8')
+  var filename = path.join(__dirname, 'external-js-callback-fail.pdf')
+  pdf
+  .create(enrichedHtml, {timeout: 2000, useDoneCallback: true, phantomArgs: ['--ignore-ssl-errors=true']})
+  .toFile(filename, function (error, pdf) {
+    t.assert(error instanceof Error, 'pdf.create(html, {useDoneCallback: true}) where callback not called')
+  })
+})
+
+test('pdf.create(html[, options]).toFile([filename, {useDoneCallback: true}], callback), where html calls window#callPhantom', function (t) {
+  t.plan(3)
+
+  var enrichedHtml = fs.readFileSync(path.join(__dirname, 'external-js-callback.html'), 'utf8')
+  var filename = path.join(__dirname, 'external-js-callback.pdf')
+  pdf
+  .create(enrichedHtml, {useDoneCallback: true, phantomArgs: ['--ignore-ssl-errors=true']})
   .toFile(filename, function (error, pdf) {
     t.error(error)
     t.assert(pdf.filename == filename, 'Returns the filename from the phantom script')


### PR DESCRIPTION
- "useDoneCallback" option added to trigger rendering the page when "window.callPhantom" called by source HTML
- If option is true and "window.callPhantom" not called, the process will time out (test written to demonstrate)

This is an attempt to address the concerns raised on [PR 133](https://github.com/marcbachmann/node-html-pdf/pull/133). It's a very simple implementation, but we require this in order to ensure that graphs and charts that we're producing using D3.js and Vega are rendered before the page is rendered for consumption by node-html-pdf.
