### PR TITLE
Change 'exit' event to 'close'

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -89,11 +89,11 @@ PDF.prototype.exec = function PdfExec (callback) {
   var stdout = []
   var stderr = []
   var timeout = setTimeout(function execTimeout () {
-    child.stdin.end()
-    child.kill()
     if (!stderr.length) {
       stderr = [new Buffer('html-pdf: PDF generation timeout. Phantom.js script did not exit.')]
     }
+    child.stdin.end()
+    child.kill()
   }, this.options.timeout)
 
   child.stdout.on('data', function (buffer) {
@@ -116,7 +116,7 @@ PDF.prototype.exec = function PdfExec (callback) {
 
   child.on('error', exit)
 
-  child.on('exit', function (code) {
+  child.on('close', function (code) {
     if (code || stderr.length) {
       var err = new Error(Buffer.concat(stderr).toString() || 'html-pdf: Unknown Error')
       return exit(err)


### PR DESCRIPTION
Now function will returned when happend 'close' event.
According to node js docs: "Note that when the 'exit' event is triggered, child process stdio streams might still be open." (https://nodejs.org/api/child_process.html#child_process_event_exit). So it is safer to use the event "close". If you use the event "exit", an error "Unexpected end of input" occurs in some cases. When using the event "close" this error does not occur.

When phantom timeout happen, error will be written before child process will killed.