### PR TITLE
Remove CoffeScript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "author": "Marc Bachmann",
   "license": "MIT",
   "devDependencies": {
-    "coffee-script": "^1.7.1",
     "standard": "^5.1.1",
     "tap-spec": "^2.2.0",
     "tape": "^3.4.0"


### PR DESCRIPTION
We no longer have any CoffeeScript files in the source code and this change removes a dependency that's no longer required.