### PR TITLE
Run as Windows Service: spawn detached

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ config = {
   "httpHeaders": {
     // e.g.
     "Authorization": "Bearer ACEFAD8C-4B4D-4042-AB30-6C735F5BAC8B"
+  },
+  
+  // To run Node application as Windows service
+  "cliOptions": {
+    "detached": true
   }
 
 }

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -85,7 +85,7 @@ PDF.prototype.toFile = function PdfToFile (filename, callback) {
 
 PDF.prototype.exec = function PdfExec (callback) {
   var callbacked = false
-  var child = childprocess.spawn(this.options.phantomPath, [].concat(this.options.phantomArgs, [this.script]))
+  var child = childprocess.spawn(this.options.phantomPath, [].concat(this.options.phantomArgs, [this.script]), this.options.cliOptions)
   var stdout = []
   var stderr = []
   var timeout = setTimeout(function execTimeout () {


### PR DESCRIPTION
If the application runs as windows service, use options = { cliOptions: { detached:true}} to avoid error: SetProcessDpiAwareness failed: "COM error 0x80070005  (Unknown error 0x0ffffffff80070005)"
Related Issues: #179 , #251 , #267  
Tested on: Windows 10 64, with NSSM service
