### PR TITLE
new toBase64 function

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -2,6 +2,7 @@ var fs = require('fs')
 var childprocess = require('child_process')
 var path = require('path')
 var assert = require('assert')
+var concat = require('concat-stream')
 
 try {
   var phantomjs = require('phantomjs-prebuilt')
@@ -70,6 +71,30 @@ PDF.prototype.toStream = function PdfToStream (callback) {
 
     callback(null, stream)
   })
+}
+
+PDF.prototype.toBase64 = function PdfToBase64(callback) {
+    this.exec(function (err, res) {
+        if (err) return callback(err)
+        try {
+            fs.createReadStream(res.filename, { encoding: 'base64' })
+              .pipe(concat(function (data) {
+                callback(null, data)
+                console.log('got data', data)
+            }))
+            
+
+            var stream = fs.createReadStream(res.filename)
+        } catch (err) {
+            return callback(err)
+        }
+        
+        stream.on('end', function () {
+            fs.unlink(res.filename, function (err) {
+                if (err) console.log('html-pdf:', err)
+            })
+        })  
+    })
 }
 
 PDF.prototype.toFile = function PdfToFile (filename, callback) {


### PR DESCRIPTION
added a new overload "toBase64" function for converting an html into a base64 string.
usage example: sending an email that received only base 64 ( send grid sdk )