### PR TITLE
use phantomJS paperSize margin property in place of border

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ config = {
   "orientation": "portrait", // portrait or landscape
 
   // Page options
-  "border": "0",             // default is 0, units: mm, cm, in, px
+  "margin": "0",             // default is 0, units: mm, cm, in, px
   - or -
-  "border": {
+  "margin": {
     "top": "2in",            // default is 0, units: mm, cm, in, px
     "right": "1in",
     "bottom": "2in",

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -32,6 +32,8 @@ function PDF (html, options) {
     this.script = path.join(__dirname, 'scripts', 'pdf_a4_portrait.js')
   }
 
+  if (this.options.border && !this.options.margin) this.options.margin = this.options.border
+
   if (this.options.filename) this.options.filename = path.resolve(this.options.filename)
   if (!this.options.phantomPath) this.options.phantomPath = phantomjs && phantomjs.path
   this.options.phantomArgs = this.options.phantomArgs || []

--- a/lib/scripts/pdf_a4_portrait.js
+++ b/lib/scripts/pdf_a4_portrait.js
@@ -192,7 +192,7 @@ function createSection (section, content, options) {
 // Creates paper with specified options
 // ------------------------------------
 function definePaperOrientation (options) {
-  var paper = {border: options.border || '0'}
+  var paper = {margin: options.margin || '0'}
 
   if (options.height && options.width) {
     paper.width = options.width


### PR DESCRIPTION
margin replaced border six years ago in phantomJS, although
backward compatibility still allows the border property
to function correctly.

This change updates html-pdf to use the margin property and
to continue recognizing the border property for backward
compatitiblity.

fixes: https://github.com/marcbachmann/node-html-pdf/issues/403
refs: https://github.com/ariya/phantomjs/commit/a638a0733992730f3bd6e2ea3d11b4ec960f51fb