### PR TITLE
A better way to handle PhantomJS exits

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -121,7 +121,7 @@ PDF.prototype.exec = function PdfExec (callback) {
     // Ignore if code has a value of 0 since that means PhantomJS has executed and exited successfully.
     // Also, as per your script and standards, having a code value of 1 means one can always assume that
     // an error occured.
-    if (typeof code !== 'undefined' && code !== 0) {
+    if ((typeof code !== 'undefined' && code !== null) && code !== 0) {
 
       var error = null;
 

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -117,13 +117,27 @@ PDF.prototype.exec = function PdfExec (callback) {
     // If we don't have an exit code, we kill the process, ignore stderr after this point
     if (code === null) kill(child, onData, onError)
 
-    if (!data) {
-      if (!err && code) err = new Error("html-pdf: Received the exit code '" + code + "'")
-      else if (!err) err = new Error('html-pdf: Unknown Error')
+    // Since code has a truthy/falsy value of either 0 or 1, check for existence first.
+    // Ignore if code has a value of 0 since that means PhantomJS has executed and exited successfully.
+    // Also, as per your script and standards, having a code value of 1 means one can always assume that
+    // an error occured.
+    if (typeof code !== 'undefined' && code !== 0) {
 
+      var error = null;
+
+      if (err) {
+        // Rudimentary checking if err is an instance of the Error class
+        error = err instanceof Error ? err : new Error(err)
+      } else {
+        // This is to catch the edge case of having a exit code value of 1 but having no error
+        error = new Error('html-pdf: Unknown Error')
+      }
+
+      // Append anything caught from the stderr
       var postfix = stderr.length ? '\n' + Buffer.concat(stderr).toString() : ''
       if (postfix) err.message += postfix
-      return callback(err, null)
+
+      return callback(error);
     }
 
     callback(null, data)

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -121,7 +121,7 @@ PDF.prototype.exec = function PdfExec (callback) {
     // Ignore if code has a value of 0 since that means PhantomJS has executed and exited successfully.
     // Also, as per your script and standards, having a code value of 1 means one can always assume that
     // an error occured.
-    if ((typeof code !== 'undefined' && code !== null) && code !== 0) {
+    if (((typeof code !== 'undefined' && code !== null) && code !== 0) || err) {
       var error = null
 
       if (err) {
@@ -134,7 +134,7 @@ PDF.prototype.exec = function PdfExec (callback) {
 
       // Append anything caught from the stderr
       var postfix = stderr.length ? '\n' + Buffer.concat(stderr).toString() : ''
-      if (postfix) err.message += postfix
+      if (postfix) error.message += postfix
 
       return callback(error)
     }

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -122,8 +122,7 @@ PDF.prototype.exec = function PdfExec (callback) {
     // Also, as per your script and standards, having a code value of 1 means one can always assume that
     // an error occured.
     if ((typeof code !== 'undefined' && code !== null) && code !== 0) {
-
-      var error = null;
+      var error = null
 
       if (err) {
         // Rudimentary checking if err is an instance of the Error class
@@ -137,7 +136,7 @@ PDF.prototype.exec = function PdfExec (callback) {
       var postfix = stderr.length ? '\n' + Buffer.concat(stderr).toString() : ''
       if (postfix) err.message += postfix
 
-      return callback(error);
+      return callback(error)
     }
 
     callback(null, data)


### PR DESCRIPTION
Consider evaluating exit codes first before actually handling errors.