### PR TITLE
Fix issue with last header appearing on all pages

### DIFF
--- a/lib/scripts/pdf_a4_portrait.js
+++ b/lib/scripts/pdf_a4_portrait.js
@@ -181,7 +181,7 @@ function createSection (section, content, options) {
       var numPagesFinal = numPages + paginationOffset
 
       if (pageNumFinal === 1 && !html) html = o.first || c.first
-      if (numPagesFinal === numPages && !html) html = o.last || c.last
+      if (pageNumFinal === numPages && !html) html = o.last || c.last
       return (html || o.default || c.default || '')
         .replace(/{{page}}/g, pageNumFinal)
         .replace(/{{pages}}/g, numPagesFinal) + content.styles


### PR DESCRIPTION
This relates to issue: https://github.com/marcbachmann/node-html-pdf/issues/390

 As noted in one of the issue comments: [comment link](https://github.com/marcbachmann/node-html-pdf/issues/390#issuecomment-364430279), version v2.2.0 of this library introduced a regression from v2.1.0

Same can be confirmed from the diff comparing [changes from v2.1.0 to v2.2.0](https://github.com/marcbachmann/node-html-pdf/compare/v2.1.0...v2.2.0#diff-c8ef83c99137993de22df9c9dfe8d1f8R179)


To note in the above comparison is the phantom script file: `lib/scripts/pdf_a4_portrait.js`, where
```javascript
if (pageNum === numPages && !html) html = o.last || c.last
```
line is changed to
```javascript
if (numPagesFinal === numPages && !html) html = o.last || c.last
```

This PR simply reverts this change.