### PR TITLE
fix(readme & pdf.js) - fix for missing comma in api example & some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # node-html-pdf
+
 ## HTML to PDF converter that uses phantomjs
+
 ![image](examples/businesscard/businesscard.png)  
 [Example Business Card](examples/businesscard/businesscard.pdf)  
- -> [and its Source file](examples/businesscard/businesscard.html)  
+ -> [and its Source file](examples/businesscard/businesscard.html)
 
 [Example Receipt](http://imgr-static.s3-eu-west-1.amazonaws.com/order.pdf)
 
@@ -25,6 +27,7 @@ $ html-pdf test/businesscard.html businesscard.pdf
 ```
 
 ## Code example
+
 ```javascript
 var fs = require('fs');
 var pdf = require('html-pdf');
@@ -41,7 +44,7 @@ pdf.create(html, options).toFile('./businesscard.pdf', function(err, res) {
 
 ```js
 var pdf = require('html-pdf');
-pdf.create(html).toFile([filepath, ]function(err, res){
+pdf.create(html).toFile([filepath, ], function(err, res){
   console.log(res.filename);
 });
 
@@ -64,6 +67,7 @@ pdf.create(html [, options], function(err, buffer){});
 `html-pdf` can read the header or footer either out of the `footer` and `header` config object or out of the html source. You can either set a default header & footer or overwrite that by appending a page number (1 based index) to the `id="pageHeader"` attribute of a html tag.
 
 You can use any combination of those tags. The library tries to find any element, that contains the `pageHeader` or `pageFooter` id prefix.
+
 ```html
 <div id="pageHeader">Default header</div>
 <div id="pageHeader-first">Header on first page</div>
@@ -77,15 +81,15 @@ You can use any combination of those tags. The library tries to find any element
 <div id="pageFooter-last">Footer on last page</div>
 ```
 
-
 ## Options
+
 ```javascript
 config = {
 
   // Export options
   "directory": "/tmp",       // The directory the file gets written into if not using .toFile(filename, callback). default: '/tmp'
 
-  // Papersize Options: http://phantomjs.org/api/webpage/property/paper-size.html
+  // Paper size Options: http://phantomjs.org/api/webpage/property/paper-size.html
   "height": "10.5in",        // allowed units: mm, cm, in, px
   "width": "8in",            // allowed units: mm, cm, in, px
   - or -

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -73,7 +73,7 @@ PDF.prototype.toStream = function PdfToStream (callback) {
 }
 
 PDF.prototype.toFile = function PdfToFile (filename, callback) {
-  assert(arguments.length > 0, 'html-pdf: The method .toFile([filename, ]callback) requires a callback.')
+  assert(arguments.length > 0, 'html-pdf: The method .toFile([filename, ], callback) requires a callback.')
   if (filename instanceof Function) {
     callback = filename
     filename = undefined
@@ -120,7 +120,7 @@ PDF.prototype.exec = function PdfExec (callback) {
     // Since code has a truthy/falsy value of either 0 or 1, check for existence first.
     // Ignore if code has a value of 0 since that means PhantomJS has executed and exited successfully.
     // Also, as per your script and standards, having a code value of 1 means one can always assume that
-    // an error occured.
+    // an error occurred.
     if (((typeof code !== 'undefined' && code !== null) && code !== 0) || err) {
       var error = null
 


### PR DESCRIPTION
- This PR contains some fixes for example section in readme file as well as in the actual pdf source file. 
- This PR also contains some typos and layout fixes.