### PR TITLE
Mention trailing slash requirement for "base" property in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ config = {
 
 
   // Rendering options
-  "base": "file:///home/www/your-asset-path", // Base path that's used to load files (images, css, js) when they aren't referenced using a host
+  "base": "file:///home/www/your-asset-path/", // Base path that's used to load files (images, css, js) when they aren't referenced using a host (must include trailing slash)
 
   // Zooming option, can be used to scale images if `options.type` is not pdf
   "zoomFactor": "1", // default is 1


### PR DESCRIPTION
As per https://github.com/marcbachmann/node-html-pdf/issues/237#issuecomment-412365493, if you don't include the trailing slash the "base" property malfunctioned. Reproduced on macOS.