### PR TITLE
node-html-pdf - Two Arbitrary File Read - Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ config = {
 
   // Export options
   "directory": "/tmp",       // The directory the file gets written into if not using .toFile(filename, callback). default: '/tmp'
+  
+  "readLocalFile": false,     // Option to help specify if access to 'local files' is allowed or not (default *false* to avoid 'arbitrary file read')
 
   // Papersize Options: http://phantomjs.org/api/webpage/property/paper-size.html
   "height": "10.5in",        // allowed units: mm, cm, in, px

--- a/bin/index.js
+++ b/bin/index.js
@@ -4,10 +4,10 @@ var fs = require('fs')
 var pdf = require('../')
 var path = require('path')
 
-const createDOMPurify = require('dompurify');
-const { JSDOM } = require('jsdom');
-const window = new JSDOM('').window;
-const DOMPurify = createDOMPurify(window);
+const createDOMPurify = require('dompurify')
+const { JSDOM } = require('jsdom')
+const window = new JSDOM('').window
+const DOMPurify = createDOMPurify(window)
 
 var args = process.argv.slice(2)
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -4,6 +4,11 @@ var fs = require('fs')
 var pdf = require('../')
 var path = require('path')
 
+const createDOMPurify = require('dompurify');
+const { JSDOM } = require('jsdom');
+const window = new JSDOM('').window;
+const DOMPurify = createDOMPurify(window);
+
 var args = process.argv.slice(2)
 
 if (args.length >= 2) {
@@ -22,7 +27,7 @@ function help () {
 }
 
 function htmlpdf (source, destination) {
-  var html = fs.readFileSync(source, 'utf8')
+  var html = DOMPurify.sanitize(fs.readFileSync(source, 'utf8'))
   var options = {
     base: 'file://' + path.resolve(source)
   }

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -34,6 +34,8 @@ function PDF (html, options) {
 
   if (this.options.filename) this.options.filename = path.resolve(this.options.filename)
   if (!this.options.phantomPath) this.options.phantomPath = phantomjs && phantomjs.path
+  if (!this.options.readLocalFile) this.options.phantomArgs.push("--local-url-access=false")
+  
   this.options.phantomArgs = this.options.phantomArgs || []
   assert(this.options.phantomPath, "html-pdf: Failed to load PhantomJS module. You have to set the path to the PhantomJS binary using 'options.phantomPath'")
   assert(typeof this.html === 'string' && this.html.length, "html-pdf: Can't create a pdf without an html string")

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -34,9 +34,9 @@ function PDF (html, options) {
 
   if (this.options.filename) this.options.filename = path.resolve(this.options.filename)
   if (!this.options.phantomPath) this.options.phantomPath = phantomjs && phantomjs.path
-  if (!this.options.readLocalFile) this.options.phantomArgs.push("--local-url-access=false")
-  
   this.options.phantomArgs = this.options.phantomArgs || []
+  
+  if (!this.options.readLocalFile) this.options.phantomArgs.push("--local-url-access=false")
   assert(this.options.phantomPath, "html-pdf: Failed to load PhantomJS module. You have to set the path to the PhantomJS binary using 'options.phantomPath'")
   assert(typeof this.html === 'string' && this.html.length, "html-pdf: Can't create a pdf without an html string")
   this.options.timeout = parseInt(this.options.timeout, 10) || 30000

--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
   "bugs": {
     "url": "https://github.com/marcbachmann/node-html-pdf/issues"
   },
-  "homepage": "https://github.com/marcbachmann/node-html-pdf"
+  "homepage": "https://github.com/marcbachmann/node-html-pdf",
+  "dependencies": {
+    "dompurify": "^2.0.8",
+    "jsdom": "^16.1.0"
+  }
 }


### PR DESCRIPTION
## Fix 1 - Arbitrary File Read

https://github.com/mufeedvh fixed the vulnerability associated with Arbitrary File Read.
This fix is being submitted on behalf of https://github.com/mufeedvh - they have been awarded $25 for fixing the vulnerability through the huntr bug bounty program.
Think you could fix a vulnerability like this - get involved (https://huntr.dev).
Q | A
Version Affected | ALL
Bug Fix | YES
Further References | https://github.com/418sec/node-html-pdf/pull/2

## Fix 2 - Arbitrary File Read

https://huntr.dev/users/Mik317 fixed the vulnerability associated with Arbitrary File Read.
This fix is being submitted on behalf of https://huntr.dev/users/Mik317 - they have been awarded $25 for fixing the vulnerability through the huntr bug bounty program.
Think you could fix a vulnerability like this - get involved (https://huntr.dev).
Q | A
Version Affected | ALL
Bug Fix | YES
Further References | https://github.com/418sec/node-html-pdf/pull/3

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-html-pdf

### ⚙️ Description *

The `node-html-pdf` module is `vulnerable` against `arbitrary file read` due to a unsafe usage of `phantomjs`, which makes possible reading `local files` when parsing `html files` to convert in `pdf ones`.

### 💻 Technical Description *

As suggested on https://github.com/marcbachmann/node-html-pdf/issues/530#issuecomment-536546934, I added as `default` argument the `--local-url-access=false` options, which makes impossible reading `local files` :smile:
The user is still able to provide access to the `local files` setting the `readLocalFile` option to `true` :smile:

### 🐛 Proof of Concept (PoC) *

1. Download the repo
2. Go on the directory `node-html-pdf`
3. Create the `poc.js` file:
```js
var fs = require('fs');
var pdf = require('./');
var html = fs.readFileSync('./test/example.html', 'utf8');
var options = { format: 'Letter' , phantomArgs: ["--web-security=no"]};

pdf.create(html, options).toFile('./example.pdf', function(err, res) {
  if (err) return console.log(err);
  console.log(res); // { filename: '/app/businesscard.pdf' }
});
```
4. `node poc.js`
5. A `example.pdf` file with the content of `/etc/passwd` is created

### 🔥 Proof of Fix (PoF) *

Same steps with fixed version doesn't create a file with the content of the `/etc/passwd` file

If the user explicity uses `readLocalFile` inside the `options`, then the `internal files` are fetched again (only who writes the code can change it, so no possible bypasses are allowed for other users :smile:)

### 👍 User Acceptance Testing (UAT)

_Run a unit test or a legitimate use case to prove that your fix does not introduce breaking changes._