### PR TITLE
Invert localUrlAccess to fix https://www.npmjs.com/advisories/1095

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -36,7 +36,7 @@ function PDF (html, options) {
   if (!this.options.phantomPath) this.options.phantomPath = phantomjs && phantomjs.path
   this.options.phantomArgs = this.options.phantomArgs || []
 
-  if (this.options.localUrlAccess) this.options.phantomArgs.push('--local-url-access=false')
+  if (!this.options.localUrlAccess) this.options.phantomArgs.push('--local-url-access=false')
   assert(this.options.phantomPath, "html-pdf: Failed to load PhantomJS module. You have to set the path to the PhantomJS binary using 'options.phantomPath'")
   assert(typeof this.html === 'string' && this.html.length, "html-pdf: Can't create a pdf without an html string")
   this.options.timeout = parseInt(this.options.timeout, 10) || 30000

--- a/test/index.js
+++ b/test/index.js
@@ -229,21 +229,6 @@ test('load with cookies js', function (t) {
   })
 })
 
-test('allows local file access with localUrlAccess=true', function (t) {
-  t.plan(2)
-
-  pdf.create(`
-    <body>here is an iframe which receives the cookies
-      <iframe src="file://${path.join(__dirname, 'multiple-pages.html')}" width="400" height="100"></iframe>
-    </body>
-  `, {localUrlAccess: true})
-  .toBuffer(function (error, buffer) {
-    t.error(error)
-    const count = buffer.toString().match(/\/Type \/Page\n/g).length
-    t.assert(count === 1, 'Renders a page with 1 page as the content is missing')
-  })
-})
-
 test('does not allow localUrlAccess by default', function (t) {
   t.plan(2)
 
@@ -252,6 +237,21 @@ test('does not allow localUrlAccess by default', function (t) {
       <iframe src="file://${path.join(__dirname, 'multiple-pages.html')}" width="400" height="100"></iframe>
     </body>
   `)
+  .toBuffer(function (error, buffer) {
+    t.error(error)
+    const count = buffer.toString().match(/\/Type \/Page\n/g).length
+    t.assert(count === 1, 'Renders a page with 1 page as the content is missing')
+  })
+})
+
+test('allows local file access with localUrlAccess=true', function (t) {
+  t.plan(2)
+
+  pdf.create(`
+    <body>here is an iframe which receives the cookies
+      <iframe src="file://${path.join(__dirname, 'multiple-pages.html')}" width="400" height="100"></iframe>
+    </body>
+  `, {localUrlAccess: true})
   .toBuffer(function (error, buffer) {
     t.error(error)
     const count = buffer.toString().match(/\/Type \/Page\n/g).length


### PR DESCRIPTION
Changelog
- Invert localUrlAccess so that access to local files is disabled by default

This also makes the option match its documented usage

built on top of changes in https://github.com/marcbachmann/node-html-pdf/pull/616