### PR TITLE
Add note about trailing slash in the base option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ config = {
 
 
   // Rendering options
-  "base": "file:///home/www/your-asset-path/", // Base path that's used to load files (images, css, js) when they aren't referenced using a host
+  "base": "file:///home/www/your-asset-path/", // Base path that's used to load files (images, css, js) when they aren't referenced using a host. The path must end with a trailing slash, other wise files wont load
 
   // Zooming option, can be used to scale images if `options.type` is not pdf
   "zoomFactor": "1", // default is 1


### PR DESCRIPTION
I have trouble with images not being loaded in PDF, reading about in #44 i realize that `base` option must have a trailing slash, as i stated in this comment https://github.com/marcbachmann/node-html-pdf/issues/44#issuecomment-1051090566

Just add a note to let it crystal clear, its easy to miss the `/`at the end